### PR TITLE
feat(rag): rag_search accepts per-RID data: source naming

### DIFF
--- a/src/deriva_mcp_core/rag/tools.py
+++ b/src/deriva_mcp_core/rag/tools.py
@@ -429,13 +429,24 @@ def register(ctx: PluginContext, env_file: str | None = None) -> None:
                     # Schema not yet indexed for this user -- exclude schema results.
                     results = [r for r in results if not r.source.startswith("schema:")]
 
-                # Restrict data: results to this user's own per-user source.
-                # data: sources are named data:{hostname}:{catalog_id}:{user_id};
-                # allowing cross-user results would expose another user's indexed rows.
+                # Restrict data: results to this user's own per-user source(s).
+                # data: sources are named either:
+                #   data:{hostname}:{catalog_id}:{user_id}             (bulk per-user)
+                # or
+                #   data:{hostname}:{catalog_id}:{user_id}:{table}:{rid} (per-RID, e.g.
+                #   deriva-ml-mcp's surgical re-index path).
+                # The accept rule is: exact-match on the bulk form, OR prefix-match
+                # on the per-RID form (own_data + ":"). The trailing colon prevents
+                # a malicious user_id like "evil-userA" from matching "data:h:c:userA"
+                # via accidental string-prefix overlap. Allowing cross-user results
+                # would expose another user's indexed rows.
                 own_data = f"data:{hostname}:{catalog_id}:{user_id}"
+                own_data_per_rid_prefix = own_data + ":"
                 results = [
                     r for r in results
-                    if not r.source.startswith("data:") or r.source == own_data
+                    if not r.source.startswith("data:")
+                    or r.source == own_data
+                    or r.source.startswith(own_data_per_rid_prefix)
                 ]
 
                 # Restrict enriched: results to this catalog only.

--- a/tests/test_rag_tools.py
+++ b/tests/test_rag_tools.py
@@ -358,6 +358,71 @@ class TestRagSearch:
         assert "data:localhost:1:anonymous" in sources
         assert "data:localhost:2:anonymous" not in sources
 
+    async def test_data_results_per_rid_source_naming_accepted(self, ctx, mock_store):
+        # data: sources may be either bulk-per-user (data:host:cat:user) or
+        # per-RID (data:host:cat:user:table:rid). Both shapes belong to the
+        # same caller and must be accepted; cross-user per-RID names must
+        # still be excluded. This pins the v1.0 -> v1.x source-naming
+        # evolution downstream plugins (e.g. deriva-ml-mcp v1.3 surgical
+        # re-index) rely on.
+        mock_store.set_search_results(
+            [
+                SearchResult(
+                    text="own bulk row", source="data:localhost:1:anonymous",
+                    doc_type="catalog-data", score=0.9, metadata={},
+                ),
+                SearchResult(
+                    text="own per-rid dataset row",
+                    source="data:localhost:1:anonymous:dataset:1-AAAA",
+                    doc_type="catalog-data", score=0.88, metadata={},
+                ),
+                SearchResult(
+                    text="own per-rid execution row",
+                    source="data:localhost:1:anonymous:execution:2-BBBB",
+                    doc_type="catalog-data", score=0.86, metadata={},
+                ),
+                SearchResult(
+                    text="bobs per-rid row",
+                    source="data:localhost:1:bob@test.org:dataset:1-CCCC",
+                    doc_type="catalog-data", score=0.84, metadata={},
+                ),
+            ]
+        )
+        tools, _ = _register_rag(ctx, mock_store)
+        result = json.loads(await tools["rag_search"]("q", hostname="localhost", catalog_id="1"))
+        sources = [r["source"] for r in result]
+        assert "data:localhost:1:anonymous" in sources
+        assert "data:localhost:1:anonymous:dataset:1-AAAA" in sources
+        assert "data:localhost:1:anonymous:execution:2-BBBB" in sources
+        assert "data:localhost:1:bob@test.org:dataset:1-CCCC" not in sources
+
+    async def test_data_results_per_rid_prefix_overlap_does_not_leak(self, ctx, mock_store):
+        # Defensive: the per-RID accept rule uses (own_data + ":") as the
+        # prefix to prevent a malicious user_id like "anonymous2" from
+        # passing the filter via accidental string-prefix overlap with
+        # "anonymous". Without the trailing colon, "data:h:c:anonymous2:..."
+        # would match the prefix "data:h:c:anonymous" -- the colon
+        # eliminates that.
+        mock_store.set_search_results(
+            [
+                SearchResult(
+                    text="own row",
+                    source="data:localhost:1:anonymous:dataset:1-AAAA",
+                    doc_type="catalog-data", score=0.9, metadata={},
+                ),
+                SearchResult(
+                    text="adversary user with prefix-overlap user_id",
+                    source="data:localhost:1:anonymous2:dataset:1-EVIL",
+                    doc_type="catalog-data", score=0.85, metadata={},
+                ),
+            ]
+        )
+        tools, _ = _register_rag(ctx, mock_store)
+        result = json.loads(await tools["rag_search"]("q", hostname="localhost", catalog_id="1"))
+        sources = [r["source"] for r in result]
+        assert "data:localhost:1:anonymous:dataset:1-AAAA" in sources
+        assert "data:localhost:1:anonymous2:dataset:1-EVIL" not in sources
+
     async def test_data_results_unfiltered_without_hostname_catalog(self, ctx, mock_store):
         # Without hostname+catalog_id, no scoping is applied and all data: results
         # are returned as-is (global search mode).


### PR DESCRIPTION
## Background

The `data:`-source filter in `rag/tools.py` (added in [`0aef9fc`](https://github.com/informatics-isi-edu/deriva-mcp-core/commit/0aef9fc), closing [#1](https://github.com/informatics-isi-edu/deriva-mcp-core/issues/1)) currently uses **exact equality** against the bulk per-user source name:

```python
own_data = f"data:{hostname}:{catalog_id}:{user_id}"
results = [
    r for r in results
    if not r.source.startswith(\"data:\") or r.source == own_data
]
```

This is correct for plugins that index in bulk under one source per user. It silently breaks plugins that index per-RID under richer source names like `data:{hostname}:{catalog_id}:{user_id}:{table}:{rid}` — those chunks land in the vector store but never appear in `rag_search` results because the exact-equality check fails.

## What this PR does

Extends the accept rule to recognize both shapes:

```python
own_data = f\"data:{hostname}:{catalog_id}:{user_id}\"
own_data_per_rid_prefix = own_data + \":\"
results = [
    r for r in results
    if not r.source.startswith(\"data:\")
    or r.source == own_data
    or r.source.startswith(own_data_per_rid_prefix)
]
```

- **Exact match** still works for the legacy bulk shape — no change for any existing plugin.
- **Prefix match** with trailing colon enables the per-RID shape.

The trailing colon is load-bearing: without it, a malicious user_id like `anonymous2` would match the prefix `data:h:c:anonymous` via accidental string-prefix overlap. The colon eliminates that.

## Why this matters now

[`deriva-ml-mcp` v1.3](https://github.com/informatics-isi-edu/deriva-ml-mcp/issues/8) introduces surgical per-RID re-indexing for Dataset/Workflow/Execution rows. After every mutating tool succeeds, the plugin refreshes just the affected source so a freshly created or modified row is searchable via `rag_search` from the next call from the same user. The current bulk-only filter would silently swallow every chunk written by that path — the feature wouldn't work end-to-end.

## Tests

60 → 62 test_rag_tools tests pass:

- `test_data_results_per_rid_source_naming_accepted` — pins the new behavior: per-RID sources for the calling user are returned; per-RID sources for other users are excluded; cross-catalog per-RID sources are also excluded.
- `test_data_results_per_rid_prefix_overlap_does_not_leak` — defensive pin on the trailing-colon security property.

All existing tests pass; legacy bulk-source plugins are unaffected.

## Backward compatibility

Strictly additive. The legacy exact-match path is preserved. No existing plugin's behavior changes.