### PR TITLE
fix(vocabulary): rename update_term_description term_name param to name

### DIFF
--- a/src/deriva_mcp_core/tools/vocabulary.py
+++ b/src/deriva_mcp_core/tools/vocabulary.py
@@ -546,7 +546,7 @@ def register(ctx: PluginContext) -> None:
         catalog_id: str,
         schema: str,
         table: str,
-        term_name: str,
+        name: str,
         description: str,
     ) -> str:
         """Update the description of a vocabulary term.
@@ -560,7 +560,7 @@ def register(ctx: PluginContext) -> None:
             catalog_id: Catalog ID or alias.
             schema: Schema name containing the vocabulary table.
             table: Vocabulary table name.
-            term_name: Primary Name of the term to update.
+            name: Primary name of the term to update.
             description: New human-readable description.
         """
         try:
@@ -568,9 +568,9 @@ def register(ctx: PluginContext) -> None:
                 catalog = get_catalog(hostname, catalog_id)
                 pb = catalog.getPathBuilder()
                 path = pb.schemas[schema].tables[table]
-                rows = list(path.filter(path.Name == term_name).entities().fetch(limit=1))
+                rows = list(path.filter(path.Name == name).entities().fetch(limit=1))
                 if not rows:
-                    return json.dumps({"error": f"Term {term_name!r} not found in {schema}:{table}"})
+                    return json.dumps({"error": f"Term {name!r} not found in {schema}:{table}"})
                 rid = rows[0]["RID"]
                 updated = list(path.update([{"RID": rid, _DESCRIPTION: description}]))
                 term = updated[0] if updated else {}
@@ -580,7 +580,7 @@ def register(ctx: PluginContext) -> None:
                 catalog_id=catalog_id,
                 schema=schema,
                 table=table,
-                term_name=term_name,
+                term_name=name,
             )
             return json.dumps({
                 "status": "updated",
@@ -596,7 +596,7 @@ def register(ctx: PluginContext) -> None:
                 catalog_id=catalog_id,
                 schema=schema,
                 table=table,
-                term_name=term_name,
+                term_name=name,
                 error_type=type(exc).__name__,
             )
             return json.dumps({"error": fmt_exc(exc)})


### PR DESCRIPTION
## Summary

Renames the public input parameter of `update_term_description` from `term_name` to `name`, aligning it with its term-CRUD siblings (`add_term`, `update_term`, `delete_term`, `lookup_term`) which all use bare `name`.

## Rationale

The deriva-py convention is to qualify name-like parameters only when another name-like field is present in the same call:

| Tool | Other name-like field? | Param |
|---|---|---|
| `lookup_term` | no | `name` ✓ |
| `add_term` | no | `name` ✓ |
| `update_term` | no | `name` ✓ |
| `delete_term` | no | `name` ✓ |
| `add_synonym` | yes (`synonym`) | `term_name` ✓ |
| `remove_synonym` | yes (`synonym`) | `term_name` ✓ |
| `update_term_description` (before) | no | `term_name` ✗ — outlier |
| `update_term_description` (after) | no | `name` ✓ |

## What this changes

- Parameter rename `term_name` → `name` (input wire format).
- Body references updated (`path.filter(path.Name == name)`, error message).
- Docstring `Args:` block updated.

## What this does NOT change

- The audit-event field stays `term_name=name` — the audit log schema is shared across all vocab audit events; renaming would break log consumers.
- `add_synonym` / `remove_synonym` are unchanged — they correctly use `term_name` because `synonym` is also a name-like field in the same call.

## Wire format note

This is a breaking change for any LLM/client passing `term_name=` by keyword. Existing tests in `tests/test_tools.py` pass the parameter positionally, so they continue to work without modification.

## Test plan

- [x] Run `update_term_description` tests — 4/4 passed
- [x] Run all vocabulary tests — 35/35 passed (98% file coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)