### PR TITLE
Add client IP capture to audit log

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,7 @@ credential access patterns, lifecycle hooks, RAG extension, and testing.
 - [Usage Guide](docs/usage-guide.md) -- natural language prompt examples for all tool categories
 - [Plugin Authoring Guide](docs/plugin-authoring-guide.md) -- writing and testing external plugins
 - [Deployment Guide](docs/deployment-guide.md) -- Docker Compose, VM, reverse proxy, vector store backends
+- [ADR-0001: Async Architecture](docs/ADR-0001-async-architecture.md) -- why ASGI/uvicorn is non-negotiable for MCP services
 
 ---
 

--- a/src/deriva_mcp_core/config.py
+++ b/src/deriva_mcp_core/config.py
@@ -155,6 +155,17 @@ class Settings(BaseSettings):
     # If unset, all authenticated users may mutate when the killswitch is off.
     mutation_required_claim: dict[str, Any] | None = None
 
+    # Set to True when this service runs behind a reverse proxy (Traefik, nginx,
+    # Apache mod_proxy) that sets X-Forwarded-For.  Enables uvicorn's
+    # ProxyHeadersMiddleware so that request.client reflects the real client IP
+    # in audit logs rather than the proxy's address.
+    #
+    # SECURITY: only enable when the service is network-isolated behind the
+    # proxy so clients cannot reach it directly and spoof X-Forwarded-For.
+    # In Docker this is enforced by the container network (no host port mapping,
+    # Traefik is the sole ingress).
+    behind_proxy: bool = False
+
     # Logging
     # Enable Python SysLogHandler for app logs (LOCAL1).  Leave False when
     # running under Docker with driver: syslog (compose handles forwarding).

--- a/src/deriva_mcp_core/server.py
+++ b/src/deriva_mcp_core/server.py
@@ -41,7 +41,7 @@ from .plugin.api import PluginContext, _set_plugin_context
 from .plugin.loader import load_plugins
 from .rag import register as _register_rag
 from .tasks.manager import TaskManager, _set_task_manager
-from .telemetry import init_audit_logger
+from .telemetry import init_audit_logger, set_client_ip
 from .tools import annotation, catalog, entity, hatrac, prompts, query, resources, schema, tasks, vocabulary
 
 logger = logging.getLogger(__name__)
@@ -350,7 +350,7 @@ def create_server(
 _MISSING = object()
 
 
-def build_http_app(mcp):
+def build_http_app(mcp, cfg: Settings | None = None):
     """Return the Starlette ASGI app for HTTP transport.
 
     In normal auth-required mode this is equivalent to mcp.streamable_http_app().
@@ -362,11 +362,29 @@ def build_http_app(mcp):
     Use this instead of mcp.streamable_http_app() both in production (main()) and
     in tests so the anonymous middleware is active when needed.
     """
+    from starlette.middleware.base import BaseHTTPMiddleware
+
+    if cfg is None:
+        cfg = _default_settings
+
     app = mcp.streamable_http_app()
     verifier = getattr(mcp, "_allow_anonymous_verifier", _MISSING)
     if verifier is not _MISSING:
         from .auth.anonymous import AnonymousPermitMiddleware
         app.add_middleware(AnonymousPermitMiddleware, verifier=verifier)
+
+    # Inner middleware: capture request.client.host into the audit contextvar.
+    # Runs after ProxyHeadersMiddleware (if enabled) has already updated request.client.
+    async def _set_client_ip(request: Request, call_next):  # type: ignore[type-arg]
+        set_client_ip(request.client.host if request.client else "unknown")
+        return await call_next(request)
+
+    app.add_middleware(BaseHTTPMiddleware, dispatch=_set_client_ip)
+
+    if cfg.behind_proxy:
+        from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
+        app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")  # type: ignore[arg-type]
+
     return app
 
 

--- a/src/deriva_mcp_core/telemetry/__init__.py
+++ b/src/deriva_mcp_core/telemetry/__init__.py
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from .audit.logger import audit_event, init_audit_logger
+from .audit.logger import audit_event, init_audit_logger, set_client_ip
 
-__all__ = ["audit_event", "init_audit_logger"]
+__all__ = ["audit_event", "init_audit_logger", "set_client_ip"]

--- a/src/deriva_mcp_core/telemetry/audit/logger.py
+++ b/src/deriva_mcp_core/telemetry/audit/logger.py
@@ -16,6 +16,7 @@
 import datetime
 import logging
 import os
+from contextvars import ContextVar
 from logging import StreamHandler
 from logging.handlers import SysLogHandler
 
@@ -25,6 +26,7 @@ from ...context import get_request_user_id_optional
 
 logger = logging.getLogger(__name__)
 svc_logger = logging.getLogger("deriva_mcp")
+_client_ip_var: ContextVar[str] = ContextVar("client_ip", default="unknown")
 
 
 def init_audit_logger(use_syslog=False):
@@ -56,6 +58,11 @@ def init_audit_logger(use_syslog=False):
     logger.propagate = False  # prevent double-emit through the root handler
 
 
+def set_client_ip(ip: str) -> None:
+    """Store the client IP for the current request in the contextvar."""
+    _client_ip_var.set(ip)
+
+
 def audit_event(event, **kwargs):
     """Emit a structured JSON audit event.
 
@@ -78,6 +85,7 @@ def audit_event(event, **kwargs):
     log_entry = {
         "event": event,
         "timestamp": datetime.datetime.now().astimezone().isoformat(),
+        "client_ip": _client_ip_var.get(),
         **extra,
         **kwargs,
     }


### PR DESCRIPTION
  Inject the real client IP into every audit event via a ContextVar.
  A BaseHTTPMiddleware in build_http_app() sets the contextvar per-request;
  ProxyHeadersMiddleware (uvicorn) is layered underneath when the new
  behind_proxy=False setting is enabled, so X-Forwarded-For is trusted only
  when the service is network-isolated behind the proxy. Adds ADR-0001
  (async architecture rationale) to the docs index.