### PR TITLE
fix(vocabulary): use deriva-py Table.define_vocabulary for canonical schema

### DIFF
--- a/src/deriva_mcp_core/tools/vocabulary.py
+++ b/src/deriva_mcp_core/tools/vocabulary.py
@@ -20,7 +20,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
-from deriva.core.ermrest_model import Column, Key, Table, builtin_types
+from deriva.core.ermrest_model import Table
 
 from . import fmt_exc
 from ..context import deriva_call, get_catalog
@@ -340,10 +340,25 @@ def register(ctx: PluginContext) -> None:
     ) -> str:
         """Create a new vocabulary table in the specified schema.
 
-        Creates a table with the standard DERIVA vocabulary column set:
-        Name (text, unique), URI (text, unique), Synonyms (json),
-        Description (markdown), ID (text, unique). System columns
-        (RID, RCT, RCB, RMT, RMB) are added automatically by ERMrest.
+        Uses deriva-py's ``Table.define_vocabulary`` so the resulting
+        table follows the canonical DERIVA vocabulary schema:
+
+        - ``ID``: ``ermrest_curie``, NOT NULL, default
+          ``"{schema}:{RID}"`` -- server-side-generated from RID.
+        - ``URI``: ``ermrest_uri``, NOT NULL, default ``"/id/{RID}"``
+          -- server-side-generated from RID.
+        - ``Name``: text, NOT NULL, unique.
+        - ``Description``: markdown, NOT NULL.
+        - ``Synonyms``: ``text[]``.
+
+        The pseudo-types ``ermrest_curie`` / ``ermrest_uri`` are the
+        load-bearing part: subsequent ``add_term`` calls submit only
+        ``Name`` (and optionally ``Description`` / ``Synonyms``) and
+        rely on the catalog to fill in ``ID`` and ``URI`` from the
+        ``RID`` via these defaults. Using plain ``text`` here -- with
+        no default -- produced a non-functional table that rejected
+        every ``add_term`` insert with a NOT NULL violation on
+        ``URI``.
 
         Args:
             hostname: Hostname of the DERIVA server.
@@ -352,25 +367,9 @@ def register(ctx: PluginContext) -> None:
             vocabulary_name: Name for the new vocabulary table.
             comment: Optional human-readable description of the vocabulary.
         """
-        table_def = Table.define(
+        table_def = Table.define_vocabulary(
             vocabulary_name,
-            column_defs=[
-                Column.define(_NAME, builtin_types.text, nullok=False,
-                              comment="Primary display name of the term"),
-                Column.define(_URI, builtin_types.text, nullok=False,
-                              comment="Unique URI identifier for the term"),
-                Column.define(_SYNONYMS, builtin_types.json, nullok=True,
-                              comment="Alternative names for the term"),
-                Column.define(_DESCRIPTION, builtin_types.markdown, nullok=True,
-                              comment="Human-readable description of the term"),
-                Column.define(_ID, builtin_types.text, nullok=False,
-                              comment="Short text identifier for the term"),
-            ],
-            key_defs=[
-                Key.define([_NAME]),
-                Key.define([_URI]),
-                Key.define([_ID]),
-            ],
+            curie_template=f"{schema}:{{RID}}",
             comment=comment,
         )
         try:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1485,6 +1485,47 @@ class TestVocabularyTools:
         assert "error" in result
         assert mock_audit.call_args[0][0] == "vocabulary_create_vocabulary_failed"
 
+    async def test_create_vocabulary_uses_canonical_pseudo_types(
+        self, ctx, mock_catalog, mock_model
+    ):
+        """ID and URI columns must use ermrest_curie / ermrest_uri pseudo-types.
+
+        Regression for B15 (surfaced by e2e Phase 6). The original
+        implementation defined URI/ID as plain text with nullok=False
+        and no default. add_term relies on the catalog to fill in ID
+        and URI from the RID via the pseudo-type defaults, so plain
+        text + NOT NULL produced a non-functional table that rejected
+        every add_term call with a NOT NULL violation on URI. Fix
+        routes through Table.define_vocabulary, which uses the
+        canonical types with the right templates.
+        """
+        model, _, _ = mock_model
+        mock_new_table = MagicMock()
+        mock_new_table.name = "Species"
+        mock_new_table.columns = []
+        captured: dict = {}
+
+        def capture_create_table(table_def):
+            captured.update(table_def)
+            return mock_new_table
+
+        model.schemas.__getitem__.return_value.create_table.side_effect = (
+            capture_create_table
+        )
+        mock_catalog.getCatalogModel.return_value = model
+        tools = self._register(ctx)
+        with self._patch_server(mock_catalog), patch(
+            "deriva_mcp_core.tools.vocabulary.audit_event"
+        ):
+            await tools["create_vocabulary"]("h", "1", "vocab", "Species", "comment")
+
+        cols = {c["name"]: c for c in captured["column_definitions"]}
+        assert cols["URI"]["type"]["typename"] == "ermrest_uri"
+        assert cols["ID"]["type"]["typename"] == "ermrest_curie"
+        assert cols["URI"]["default"] == "/id/{RID}"
+        assert "{RID}" in cols["ID"]["default"]
+        assert cols["ID"]["default"].startswith("vocab:")
+
     # -- add_synonym --
 
     async def test_add_synonym_synonyms_invalid_json_string(self, ctx, mock_catalog):


### PR DESCRIPTION
## Summary

\`create_vocabulary\` produced non-functional vocabulary tables. The original implementation defined \`ID\` and \`URI\` as plain \`text\` with \`nullok=False\` and no server-side default. Subsequent \`add_term\` calls submit only \`Name\` (and optionally \`Description\` / \`Synonyms\`) and rely on the catalog to fill in \`ID\` and \`URI\` from the \`RID\` via the pseudo-type defaults. With plain text + NOT NULL + no default, every \`add_term\` insert was rejected with:

\`\`\`
null value in column \"URI\" violates not-null constraint
\`\`\`

Fix: route through deriva-py's \`Table.define_vocabulary\`, which produces the canonical DERIVA vocabulary schema:

- \`ID\`: \`ermrest_curie\`, NOT NULL, default \`\"{schema}:{RID}\"\` -- server-side-generated from RID.
- \`URI\`: \`ermrest_uri\`, NOT NULL, default \`\"/id/{RID}\"\` -- server-side-generated from RID.
- \`Name\`: text, NOT NULL, unique.
- \`Description\`: markdown, NOT NULL.
- \`Synonyms\`: \`text[]\`.

The pseudo-types are the load-bearing part: they tell ERMrest to auto-generate values from the RID, which is what \`add_term\` relies on. The curie template uses \`{schema}:{RID}\` so terms carry a stable, schema-scoped identifier.

## How surfaced

E2E Phase 6 against catalog 46. Creating a new \`Prediction_Confidence_Bucket\` vocabulary on the domain schema, then trying to add a \`Low\` term -- failed with the NOT NULL violation above. Compare to existing \`Image_Class\` on the same catalog (created by deriva-ml's own \`_create_vocabulary\` schema-creation path), which uses the canonical pseudo-types and accepts \`add_term\` calls cleanly.

## Test plan

- [x] \`tests/test_tools.py::test_create_vocabulary_uses_canonical_pseudo_types\` -- new regression test asserting the captured \`table_def\` has \`type.typename == \"ermrest_uri\"\` for URI and \`\"ermrest_curie\"\` for ID, with default templates containing \`{RID}\` and the schema-scoped prefix on ID.
- [x] Existing \`test_create_vocabulary\` and \`test_create_vocabulary_error\` unchanged and still pass. 3/3 vocab tests green.
- [x] Broader non-integration suite: 6 pre-existing failures + 6 errors in \`tests/test_rag_crawler.py::TestWebCrawlerCrawl\` -- verified present on \`main\` before this change, unrelated to vocabulary code.
- [ ] E2E verification on catalog 46 after this lands: rebuild MCP container, retry \`create_vocabulary(Confidence_Bucket)\` + \`add_term(Low/Medium/High)\`; should succeed cleanly.

Removed \`Column\` / \`Key\` / \`builtin_types\` imports -- no longer used in this module after the refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)